### PR TITLE
Add Gammapy team info page

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Gammapy - Contributors</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css"
+          integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
+    <link rel="stylesheet" href="style.css" media="screen" charset="utf-8">
+</head>
+
+<body>
+
+<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+    <a class="navbar-brand" href=".">Gammapy</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse"
+            aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarCollapse">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item"><a class="nav-link" href="news.html">News</a></li>
+            <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+            <li class="nav-item"><a class="nav-link" href="cta.html">CTA</a></li>
+            <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="" data-toggle="dropdown" aria-haspopup="true"
+                   aria-expanded="false">Documentation</a>
+                <div class="dropdown-menu" aria-labelledby="documentation">
+                    <a class="dropdown-item"
+                       href="http://docs.gammapy.org/en/latest/">
+                        Development version
+                    </a>
+                    <a class="dropdown-item"
+                       href="http://docs.gammapy.org/en/stable/">
+                        Latest stable version
+                    </a>
+                </div>
+            </li>
+        </ul>
+    </div>
+</nav>
+
+<main role="main">
+    <div class="container">
+        <h4> List of contributors</h4>
+        <ol class="list-unstyled">
+            <li>Acero, Fabio (@facero)</li>
+            <li>Bühler, Rolf (@rbuehler)</li>
+            <li>Chakraborty, Nachiketa (@cnachi)</li>
+            <li>Deil, Christoph (@cdeil)</li>
+            <li>Deiml, Peter (@pdeiml)</li>
+            <li>de Oña-Wilhelmi, Emma ()</li>
+            <li>Donath, Axel (@adonath)</li>
+            <li>Gogia, Arpit (@arpitgogia)</li>
+            <li>Harris, Jonathan (@JonathanDHarris)</li>
+            <li>Jouvin, Lea (@JouvinLea)</li>
+            <li>Khelifi, Bruno</li>
+            <li>King, Johannes< (@joleroi)</li>
+            <li>Klepser, Stefan (@klepser)</li>
+            <li>Lefaucheu, Julien (@jjlk)</li>
+            <li>Lennarz, Dirk (@dlennarz)</li>
+            <li>Lopez-Coto, Ruben (@rlopezcoto)</li>
+            <li>Mestre, Enrique (@)</li>
+            <li>Mohrmann, Lars (@lmohrmann)</li>
+            <li>Nigro, Cosimo (@cosimoNigro)</li>
+            <li>Owen, Ellis (@ellisowen)</li>
+            <li>Paz Arribas, Manuel (@mapazarr)</li>
+            <li>Poon, Helen (@helen-poon)</li>
+            <li>Reichardt, Ignasi (@ignasi-reichardt)</li>
+            <li>Ruiz, José Enrique (@Bultako)</li>
+            <li>Sipocz, Brigitta (@bsipocz)</li>
+            <li>Terrier, Regis (@registerrier)</li>
+            <li>Tibaldo, Luigi (@tibaldo)</li>
+            <li>Tiziani, Domenico (@dltiziani)</li>
+            <li>Vinícius, Ze (@mirca)</li>
+            <li>Vorokh, Olga (@OlgaVorokh)</li>
+            <li>Voruganti, Arjun (@vorugantia)</li>
+            <li>Wegen, Matthias (@wegenmat)</li>
+            <li>Wood, Matthiew (@woodmd)</li>
+            <li>Zabalza, Victor (@zblz)</li>
+            <li>Zanin, Roberta (@robertazanin)</li>
+        </ol>
+    </div>
+</main>
+
+<footer class="container">
+    <hr>
+    <p>&copy; Gammapy project</p>
+</footer>
+
+
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+        integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+        crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js"
+        integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh"
+        crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js"
+        integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ"
+        crossorigin="anonymous"></script>
+
+</body>
+</html>

--- a/roles.html
+++ b/roles.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Gammapy - Roles</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css"
+          integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
+    <link rel="stylesheet" href="style.css" media="screen" charset="utf-8">
+</head>
+
+<body>
+
+<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+    <a class="navbar-brand" href=".">Gammapy</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse"
+            aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarCollapse">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item"><a class="nav-link" href="news.html">News</a></li>
+            <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+            <li class="nav-item"><a class="nav-link" href="cta.html">CTA</a></li>
+            <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="" data-toggle="dropdown" aria-haspopup="true"
+                   aria-expanded="false">Documentation</a>
+                <div class="dropdown-menu" aria-labelledby="documentation">
+                    <a class="dropdown-item"
+                       href="http://docs.gammapy.org/en/latest/">
+                        Development version
+                    </a>
+                    <a class="dropdown-item"
+                       href="http://docs.gammapy.org/en/stable/">
+                        Latest stable version
+                    </a>
+                </div>
+            </li>
+        </ul>
+    </div>
+</nav>
+
+<main role="main">
+    <div class="container">
+        <h4> Roles</h4>
+
+        <table id="gammapy-roles">
+            <thead>
+            <tr>
+                <th>Role</th>
+                <th>Sub-role</th>
+                <th>Lead</th>
+                <th>Deputy</th>
+            </tr>
+            </thead>
+            <tr>
+                <td><a href="#Coordination_committee_member">Coordination committee member</a></td>
+                <td></td>
+                <td>Christoph Deil</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td></td>
+                <td></td>
+                <td>Bruno Khelifi</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td></td>
+                <td></td>
+                <td>Roberta Zanin</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td></td>
+                <td></td>
+                <td>Regis Terrier</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td><a href="#Documentation_coordinator">Documentation coordinator</a></td>
+                <td></td>
+                <td>TBD</td>
+                <td></td>
+            </tr>
+            <tr>
+            <tr>
+                <td><a href="#Gammapyorg_web_page_maintainer">gammapy.org web page maintainer</a></td>
+                <td></td>
+                <td>TBD</td>
+            </tr>
+            <td><a href="#Distribution_coordinator">Distribution coordinator</a></td>
+            <td>Conda</td>
+            <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>ArchLinux</td>
+                <td>TDB</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>MacPorts</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>Windows</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td><a href="#Core_package_release_coordinator">Core package release coordinator</a></td>
+                <td></td>
+                <td>Christoph Deil</td>
+            </tr>
+            <tr>
+                <td><a href="#Subpackage_maintainer">Sub-package maintainer</a></td>
+                <td>gammapy.astro</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.background</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.catalog</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.cube</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.data</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.datasets</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.detect</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.extern</td>
+                <td>Christoph Deil</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.image</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.irf</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.maps</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.scripts</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.spectrum</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.stats</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.tests</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.time</td>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>gammapy.utils</td>
+                <td>TBD</td>
+            </tr>
+        </table>
+    </div>
+</main>
+
+<footer class="container">
+    <hr>
+    <p>&copy; Gammapy project</p>
+</footer>
+
+
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+        integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+        crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js"
+        integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh"
+        crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js"
+        integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ"
+        crossorigin="anonymous"></script>
+
+</body>
+</html>

--- a/team.html
+++ b/team.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Gammapy - Team</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css"
+          integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
+    <link rel="stylesheet" href="style.css" media="screen" charset="utf-8">
+</head>
+
+<body>
+
+<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+    <a class="navbar-brand" href=".">Gammapy</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse"
+            aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarCollapse">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item"><a class="nav-link" href="news.html">News</a></li>
+            <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+            <li class="nav-item"><a class="nav-link" href="cta.html">CTA</a></li>
+            <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="" data-toggle="dropdown" aria-haspopup="true"
+                   aria-expanded="false">Documentation</a>
+                <div class="dropdown-menu" aria-labelledby="documentation">
+                    <a class="dropdown-item"
+                       href="http://docs.gammapy.org/en/latest/">
+                        Development version
+                    </a>
+                    <a class="dropdown-item"
+                       href="http://docs.gammapy.org/en/stable/">
+                        Latest stable version
+                    </a>
+                </div>
+            </li>
+        </ul>
+    </div>
+</nav>
+
+<main role="main">
+
+    <div class="container">
+        <div class="row">
+            <div class="col-6 col-md-3 sidebar-offcanvas" id="sidebar">
+                <div class="list-group">
+                    <a href="contributors.html" class="list-group-item active">Contributors</a>
+                    <a href="roles.html" class="list-group-item">Responsability roles</a>
+                </div>
+            </div>
+            <div class="col-6 col-md-8" id="main">
+
+                <h2 id="roles-responsibilities"> Gammapy Project Role Responsibilities </h2>
+                <p>The gammapy project is made possible through the efforts of <a href="contributors.html">community
+                    members</a>
+                    that perform numerous important roles. This encompasses abroad scope of responsibilities ranging
+                    from direct
+                    package development to communication, distribution, and managerial activities. In this section we
+                    list the
+                    responsibilities for each of the identified project roles. The list of people fulfilling these roles
+                    is found
+                    in the <a href="roles.html">Roles</a> section.
+                </p>
+
+                <br/>
+                <h3 id="cc">Coordination committee</h3>
+                <p>
+                    The Gammapy coordination committe was started in November 2017 with members: Bruno Khelifi, Régis Terrier, Roberta Zanin and
+                Christoph Deil. We are starting by improving Gammapy project documentation and communication channels
+                and organising meetings (regular calls and next coding sprint).
+                We will the meet in December 2017 and discuss how to set up the Gammapy project, by defining tasks for
+                the coordination committe and other roles in the Gammapy project, and then recruiting people
+                    in early 2018 to work on Gammapy and to grow the Gammapy project and coordination committee.
+
+                </p>
+                <p>Overall coordination and management of the gammapy project, including:</p>
+                <ul>
+                    <li>Keeping a large-scale view of the Astropy ecosystem</li>
+                    <li>Evaluating new affiliated package submissions and review of existing
+                        affiliated packages
+                    </li>
+                    <li>Evaluating and merging core package pull requests as needed
+                        (e.g., for sub-packages without a maintainer)
+                    </li>
+                    <li>Arbitrating disagreements in the core package, including final decisions
+                        when otherwise deadlocked
+                    </li>
+                    <li>Maintaining the list of roles and related github permissions</li>
+                </ul>
+
+                <br/>
+                <h3 id="Gammapyorg_web_page_maintainer">Gammapy.org web page maintainer</h3>
+                <p>Manage the <a href="http://gammapy.org">gammapy.org</a> web site,
+                    including:</p>
+                <ul>
+                    <li>Maintaining contributor/roles list</li>
+                    <li>Managing pull requests to the website repository</li>
+                </ul>
+
+                <br/>
+                <h3 id="Distribution_coordinator">Distribution
+                    coordinator (1 per distribution channel)</h3>
+                <p>Create and maintain binary distribution packages for Gammapy core and
+                    affiliated packages for a specific OS or package management system.</p>
+
+                <br/>
+                <h3 id="Subpackage_maintainer">Sub-package
+                    maintainer (1 per core package sub-package)</h3>
+                <p>Maintain a sub-package of the gammapy core package, including:</p>
+                <ul>
+                    <li>Evaluating new pull requests for quality, API consistency, Gammapy coding
+                        standards, and appropriateness within the overall astropy ecosystem.
+                    </li>
+                    <li>Merging Pull Requests in the sub-package</li>
+                    <li>Keeping track of the “big picture” progress of the sub-package - includes
+                        new feature development and significant bugs.
+                    </li>
+                    <li>Keeping track of frequent contributors to the sub-package and their
+                        relevant areas of expertise.
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</main>
+
+<footer class="container">
+    <hr>
+    <p>&copy; Gammapy project</p>
+</footer>
+
+
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+        integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+        crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js"
+        integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh"
+        crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js"
+        integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ"
+        crossorigin="anonymous"></script>
+
+</body>
+</html>


### PR DESCRIPTION
@robertazanin @bkhelifi - I'm splitting out these Gammapy team info pages from #1 to this new pull request. They will take significantly more discussion and work to define the roles and coordination committee tasks in a good way. @bkhelifi - I suggest we do that together when you are in HD in 2 weeks.

For now, I want to merge #1 today and have it go live, and even if we don't link to those pages ourselves, Google would pick them up and some people would find them via Google search.