### PR TITLE
Add conda env file for release v0.8

### DIFF
--- a/cfg/environment_v08.yml
+++ b/cfg/environment_v08.yml
@@ -1,0 +1,34 @@
+# Conda environment for Gammapy stable versions
+# Install:    conda env create -f environment_v08.yml
+# Activate:   source activate gammapy_v08
+# Deactivate: source deactivate
+
+name: gammapy_v08
+
+channels:
+  - conda-forge
+  - sherpa
+
+dependencies:
+  - python==3.6
+  - ipython==6.5.0
+  - jupyter==1.0.0
+  - jupyterlab==0.33.8
+  - jupyterlab_launcher==0.11.2
+  - cython==0.28.5
+  - numpy==1.13
+  - astropy==3.0.4
+  - regions==0.2
+  - click==6.7
+  - pyyaml==3.12
+  - scipy==0.19.1
+  - photutils==0.4
+  - reproject==0.4
+  - uncertainties==3.0.2
+  - naima==0.8.1
+  - iminuit==1.2
+  - sherpa==4.10
+  - healpy==1.11.0
+  - matplotlib==2.2.2
+  - pandas==0.23.4
+  - gammapy==0.8


### PR DESCRIPTION
This PR adds a conda env file for release v0.8, as discussed in https://github.com/gammapy/gammapy/issues/1725

The `cfg` folder could host any other config file needed (json or yaml) i.e. list of notebooks used in tutorials, datasets used in tutorials, env files for other gammapy versions, etc.  If we decide to get rid of Github for these files, the files in `cfg` folder could be used. 

- https://github.com/gammapy/gammapy/blob/8ea7f92e758eca32386d468fcdfef479ee567703/docs/development/pigs/pig-004.rst

- https://github.com/gammapy/gammapy/pull/1369

