### PR TITLE
Fix gammapy-0.8-environment.yml file

### DIFF
--- a/download/install/gammapy-0.8-environment.yml
+++ b/download/install/gammapy-0.8-environment.yml
@@ -16,19 +16,19 @@ dependencies:
   - jupyterlab==0.33.8
   - jupyterlab_launcher==0.11.2
   - cython==0.28.5
-  - numpy==1.13
+  - numpy==1.15.1
   - astropy==3.0.4
   - regions==0.3
   - click==6.7
   - pyyaml==3.12
-  - scipy==0.19.1
+  - scipy==1.1.0
   - reproject==0.4
   - uncertainties==3.0.2
   - naima==0.8.1
   - iminuit==1.3.2
   - sherpa==4.10
   - healpy==1.11.0
-  - matplotlib==2.2.3
+  - matplotlib==2.1.1
   - pandas==0.23.4
   
   - pip:


### PR DESCRIPTION
The current `gammapy-0.8-environment.yml` file results in an `UnsatisfiableError` when trying to call `conda env create -f ...`. This PR updates the numpy, scipy and matplotlib versions to get an environment, that can be resolved.