### PR TITLE
Update team.html

### DIFF
--- a/team.html
+++ b/team.html
@@ -100,7 +100,6 @@
             <li><a href="#coordination-committee">Coordination committee</a></li>
             <li><a href="#project-manager">Project manager</a></li>
             <li><a href="#lead-developer">Lead developer</a></li>
-            <li><a href="#core-developers">Core developers</a></li>
             <li><a href="#contributors">Contributors</a></li>
         </ul>
 
@@ -172,7 +171,7 @@
         </p>
         <p>
             The project manager is appointed by the Gammapy coordination committee, and works closely with the Gammapy
-            coordination committee, core developers and users.
+            coordination committee, contributors and users.
         </p>
         <p>
             Responsibilities include:
@@ -187,7 +186,7 @@
                 Serve as Gammapy coordination committee secretary (schedule and moderate calls; give status reports;
                 write minutes)
             </li>
-            <li>Organise all Gammapy calls and face-to-face meetings (for users and / or developers) via <a
+            <li>Organise Gammapy user calls and training events via <a
                     href="https://github.com/gammapy/gammapy-meetings/">gammapy-meetings</a>
             </li>
             <li>
@@ -203,10 +202,6 @@
         <p>
             The current project manager is <strong>Bruno Khelifi</strong>, the deputy project manager is <strong> Christopher van Eldik</strong>.
         </p>
-        <p class="small">
-            The role of project manager is very time-intensive. The project manager and deputy should aim to distribute
-            tasks to other contributors in the Gammapy team, and split the remaining work.
-        </p>
 
         <h2 id="lead-developer">Lead developer</h2>
         <p class="lead">
@@ -214,7 +209,7 @@
         </p>
         <p>
             The lead developer is appointed by the Gammapy coordination committee, and works closely with the Gammapy
-            coordination committee, project manager, core developers and community contributors.
+            coordination committee, project manager and contributors.
         </p>
         <p>
             Responsibilities include:
@@ -247,6 +242,9 @@
                 Ensure Gammapy infrastructure is well set up and maintained (issue tracker and pull requests on Github,
                 continuous integration tests, documentation builds, releases and distribution).
             </li>
+            <li>Organise Gammapy developer calls and coding sprints via <a
+                href="https://github.com/gammapy/gammapy-meetings/">gammapy-meetings</a>
+            </li>
             <li>
                 Schedule Gammapy releases and define which fixes and features go in which release, taking the needs of
                 people and projects using Gammapy as well as available manpower for developments into account.
@@ -256,20 +254,6 @@
         <p>
             The current lead developers are <strong>Christoph Deil</strong>,
             <strong>Régis Terrier</strong> and <strong>Axel Donath</strong>.
-        </p>
-        <p class="small">
-            The role of lead developer is very time-intensive. The lead developer and deputy should aim to distribute
-            tasks to other core developers and contributors in the Gammapy team, and split the remaining work.
-        </p>
-
-        <h2 id="core-developers">Core developers</h2>
-        <p class="lead">The Gammapy core developers regularly contribute to Gammapy, either by writing code, tests or
-            documentation themselves, or by doing review, maintenance, refactoring or cleanup for parts of the Gammapy
-            code.
-        </p>
-        <p>
-            We will define roles and responsibilites for Gammapy core development team and describe them here in
-            February 2017.
         </p>
 
         <h2 id="contributors">Contributors</h2>


### PR DESCRIPTION
- Remove core developer role (was never defined and isn't clearly defined)
- Move responsibility for dev calls and coding sprints from PM to lead devs (works better, what we already did in the past year)