### PR TITLE
Adapt sizes for compatibility with any webpage

### DIFF
--- a/about.html
+++ b/about.html
@@ -145,7 +145,7 @@
         <h3>In Presentations</h3>
         <p>If you are giving a presentation or talk featuring work/research that makes
             use of Gammapy we would like to ask you to acknowledge Gammapy by using this logo
-        <p><img width="500px" draggable="false" src="img/gammapy_banner.png" alt="Gammapy banner"/></p>
+        <p><img style="width:70%;" draggable="false" src="img/gammapy_banner.png" alt="Gammapy banner"/></p>
         </p>
 
         <br><br>

--- a/news.html
+++ b/news.html
@@ -461,10 +461,10 @@
         <h1 id="stats"><a href="#stats">Download statistics</a></h1>
         <br>
         <p>
-            Download statistics can be found using the <a href="https://pypistats.org/packages/gammapy">PyPI stats web site</a>:
+            Download statistics can be found using the <a href="https://pypistats.org/packages/gammapy">PyPI stats website</a>:
         </p>
 
-        <iframe src="https://pypistats.org/packages/gammapy" width="1000" height="800"></iframe>
+        <iframe src="https://pypistats.org/packages/gammapy"  width="100%" height="800"></iframe>
 
         <br><br>
         <p>

--- a/team.html
+++ b/team.html
@@ -328,7 +328,7 @@
           </p>
 
           <p> The list of sub-package maintainers is given below:
-              <table>
+              <table width="80%" border="0" cellspacing="0" cellpadding="0">
                   <tr>
                       <th>Maintainer</th>
                       <th>Sub-package(s)</th>
@@ -364,7 +364,7 @@
             or mentoring or organisational work for Gammapy it does not show up in the commit statistic at all.
             Please know that any contribution to the Gammapy project is valued!
         </p>
-        
+
         <p>
             The list of contributions into conferences, hands-on sessions and schools, and for recipies can be found on the following list:
            <ul>
@@ -405,7 +405,7 @@
         </p>
         <br>
         <center>
-            <img src="img/LogoList_V2021_V2.png" alt="Institutions supporting the project" align="middle">
+            <img src="img/LogoList_V2021_V2.png" style="width:70%;" alt="Institutions supporting the project" align="middle">
         </center>
 
         <br><br>


### PR DESCRIPTION
Resolves [#26](https://github.com/gammapy/gammapy-webpage/issues/26)

Adapts the widths to be in percentages rather than set width sizes, therefore these should appear nicely on every webpage they are accessed from. Especially the mobile versions