### PR TITLE
Update of the responsabilities (2)

### DIFF
--- a/team.html
+++ b/team.html
@@ -69,6 +69,7 @@
                 <li><a href="#project-manager">Project managers</a></li>
                 <li><a href="#lead-developer">Lead developers</a></li>
                 <li><a href="#module-maintainer">Sub-package maintainers</a></li>
+                <li><a href="#other-respon">Other responsibilities</a></li>
                 <li><a href="#contributors">Contributors</a></li>
                 <li><a href="#support">Institutional support</a></li>
             </ul>
@@ -228,7 +229,8 @@
                 </li>
             </ul>
             <p>
-                The current lead developers are <strong>Axel Donath</strong> and <strong>Régis Terrier</strong>.
+                The current lead developers are <strong>Régis Terrier</strong> (APC), <strong>Axel Donath</strong> (CfA),
+                <strong>Atreyee Sinha</strong> (IFJ PAN) and <strong>Quentin Remy</strong> (MPIK).
             </p>
 
             <br><br>
@@ -266,6 +268,18 @@
                   </table>
               </p>
 
+            <br><br>
+            <h2 id="other-respon"><a href="#other-respon">Other responsibilities</a></h2>
+            <p>
+                Some activities are transverse to sub-packages and require a global overview and coordination. Here is the
+                list of persons dedicated to specific activity:
+                <ul>
+                    <li>documentation: K. Feijen (APC),</li>
+                    <li>CI or DevOps: D. Morcuende (IAA-CSIC),</li>
+                    <li>general website: B. Khélifi (APC) and H. Stapel (APC),</li>
+                    <li>user calls: A. Sinha (IFJ PAN).</li>
+                </ul>
+            </p>
 
             <br><br>
             <h2 id="contributors"><a href="#contributor">Contributors</a></h2>


### PR DESCRIPTION
This PR updates the website about the list of responsibilities.
It includes :
- the lead developers,
- add a section on "other responsabilities" with the general website, the documentation, the devops
