### PR TITLE
Mention the new Lead-developer mailing list

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -44,6 +44,18 @@
                     To get access, sign-up <a href="https://join.slack.com/t/gammapy/signup">here</a>, and wait a bit for moderator approval.
                 </li>
                 <li>
+                    Gammapy Lead-Developers mailing list
+                    (<a href="mailto:gammapy-ld-l@in2p3.fr">gammapy-ld-l [at] in2p3 [dot] fr</a>,
+                    <a href="https://listserv.in2p3.fr/archives/gammapy-ld-l.html">archive</a>)
+                    <br>
+                    Use this mailing list to contact the Gammapy Lead Developers and Project Managers.
+                    Anyone can post, and the emails are <strong>public</strong>.
+                    Don't be shy: just email us if you have any question or comment about Gammapy!
+
+                    Ask any question about CTAO data analysis with Gammapy.
+                    This is a <strong>public</strong> mailing list, so discussing CTAO-internal information is OK.
+                </li>
+                <li>
                     Gammapy CTAO mailing list
                     (<a href="mailto:gammapy-cta-l@in2p3.fr">gammapy-cta-l [at] in2p3 [dot] fr</a>,
                     <a href="https://listserv.in2p3.fr/archives/gammapy-cta-l.html">archive</a>)

--- a/team.html
+++ b/team.html
@@ -139,6 +139,9 @@
                 <li><strong>Rub&eacute;n L&oacute;pez-Coto</strong> (IAA/CSIC, Spain)</li>
                 <li><strong>Stefan Funk</strong> (Erlangen University, Germany)</li>
             </ul>
+            <p>
+                The committee can be contact by email: <a href="mailto:gammapy-coordination-l@in2p3.fr">gammapy-coordination-l [at] in2p3 [dot] fr</a>.
+            </p>
 
             <br><br>
             <h2 id="project-manager"><a href="#pm"> Project managers </a></h2>
@@ -231,6 +234,9 @@
             <p>
                 The current lead developers are <strong>Régis Terrier</strong> (APC), <strong>Axel Donath</strong> (CfA),
                 <strong>Atreyee Sinha</strong> (TIFR) and <strong>Quentin Remy</strong> (MPIK).
+            </p>
+            <p>
+                The Lead Developers can be contact by email: <a href="mailto:gammapy-ld-l@in2p3.fr">gammapy-ld-l [at] in2p3 [dot] fr</a>.
             </p>
 
             <br><br>


### PR DESCRIPTION
This PR adds a new mailing list to contact the lead developers and the project managers.

It is associated with the issue #64.