### PR TITLE
Add email obfuscation

### DIFF
--- a/CoC.html
+++ b/CoC.html
@@ -72,16 +72,18 @@
         </p>
         
         <br><hr><br>
-        <p> In order to report any information or issue, please contact the Gammapy Coordination Committee using its
-        <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#111;&#111;&#114;&#100;&#105;&#110;&#97;&#116;&#105;&#111;&#110;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;"> generic email</a>, 
-        or any member of the Coordination Committee (see its composition 
-        <a href="team.html#coordination-committee">here</a>).
-        </p>
+	<p>
+	  In order to report any information or issue, please contact the Gammapy Coordination Committee using its 
+	  <a id="link-conversion" rel="nofollow noindex" href="email*/" rel="nofollow noindex">generic email</a>, 
+	  or any member of the Coordination Committee (see its composition 
+	  <a href="team.html#coordination-committee">here</a>).
+	</p>
     </div>
 </main>
 
     <!-- Footer Section -->
     <div id="footer-placeholder"></div>
     <script src="scripts/load-components.js"></script>
+    <script src="scripts/link-conversion.js"></script>
 </body>
 </html>

--- a/CoC.html
+++ b/CoC.html
@@ -73,8 +73,9 @@
         
         <br><hr><br>
         <p> In order to report any information or issue, please contact the Gammapy Coordination Committee using its
-        generic email, <a href="mailto:gammapy-coordination-l@in2p3.fr">gammapy-coordination-l [at] in2p3 [dot] fr</a>, or any
-        member of the Coordination Committee (see its composition <a href="team.html#coordination-committee">here</a>).
+        <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#111;&#111;&#114;&#100;&#105;&#110;&#97;&#116;&#105;&#111;&#110;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;"> generic email</a>, 
+        or any member of the Coordination Committee (see its composition 
+        <a href="team.html#coordination-committee">here</a>).
         </p>
     </div>
 </main>

--- a/contact.html
+++ b/contact.html
@@ -42,12 +42,12 @@
                     The Gammapy slack is private, and the history is not archived, i.e. is lost at some point.
                     <br>
                     Sign up at <a href="https://join.slack.com/t/gammapy/signup">here</a>, and wait a bit for moderator approval,
-                    or send an email <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#108;&#100;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">here</a> 
+                    or send an email <a class="link-conversion" data-replace="#" href="email#/" rel="nofollow noindex">here</a>
                     if you need an invitation.
                 </li>
                 <li>
                     Gammapy Lead-Developers mailing list
-                    (<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#108;&#100;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email</a>,
+                    (<a class="link-conversion" data-replace="#" href="email#/" rel="nofollow noindex">email</a>,
                     <a href="https://listserv.in2p3.fr/archives/gammapy-ld-l.html">archive</a>)
                     <br>
                     Use this mailing list to contact the Gammapy Lead Developers and Project Managers.
@@ -56,7 +56,7 @@
                 </li>
                 <li>
                     Gammapy CTAO mailing list
-                    (<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#116;&#97;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email</a>,
+                    (<a class="link-conversion" data-replace="&" href="email&/" rel="nofollow noindex">email</a>,
                     <a href="https://listserv.in2p3.fr/archives/gammapy-cta-l.html">archive</a>)
                     <br>
                     Ask any question about CTAO data analysis with Gammapy.
@@ -71,7 +71,7 @@
                 </li>
                 <li>
                     Gammapy coordination committee mailing list
-                    (<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#111;&#111;&#114;&#100;&#105;&#110;&#97;&#116;&#105;&#111;&#110;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email</a>,
+                    (<a class="link-conversion" data-replace="*" href="email*/" rel="nofollow noindex">email</a>,
                     <a href="https://listserv.in2p3.fr/archives/gammapy-coordination-l.html">archives</a>)
                     <br>
                     Use this mailing list to contact the Gammapy coordination committee.
@@ -94,6 +94,7 @@
     <!-- Footer Section -->
     <div id="footer-placeholder"></div>
     <script src="scripts/load-components.js"></script>
+    <script src="scripts/link-conversion.js"></script>    
 
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -42,11 +42,12 @@
                     The Gammapy slack is private, and the history is not archived, i.e. is lost at some point.
                     <br>
                     Sign up at <a href="https://join.slack.com/t/gammapy/signup">here</a>, and wait a bit for moderator approval,
-                    or send an email to <a href="mailto:gammapy-ld-l@in2p3.fr">gammapy-ld-l [at] in2p3 [dot] fr</a> if you need an invitation.
+                    or send an email <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#108;&#100;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">here</a> 
+                    if you need an invitation.
                 </li>
                 <li>
                     Gammapy Lead-Developers mailing list
-                    (<a href="mailto:gammapy-ld-l@in2p3.fr">gammapy-ld-l [at] in2p3 [dot] fr</a>,
+                    (<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#108;&#100;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email</a>,
                     <a href="https://listserv.in2p3.fr/archives/gammapy-ld-l.html">archive</a>)
                     <br>
                     Use this mailing list to contact the Gammapy Lead Developers and Project Managers.
@@ -55,7 +56,7 @@
                 </li>
                 <li>
                     Gammapy CTAO mailing list
-                    (<a href="mailto:gammapy-cta-l@in2p3.fr">gammapy-cta-l [at] in2p3 [dot] fr</a>,
+                    (<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#116;&#97;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email</a>,
                     <a href="https://listserv.in2p3.fr/archives/gammapy-cta-l.html">archive</a>)
                     <br>
                     Ask any question about CTAO data analysis with Gammapy.
@@ -70,7 +71,7 @@
                 </li>
                 <li>
                     Gammapy coordination committee mailing list
-                    (<a href="mailto:gammapy-coordination-l@in2p3.fr">gammapy-coordination-l [at] in2p3 [dot] fr</a>,
+                    (<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#111;&#111;&#114;&#100;&#105;&#110;&#97;&#116;&#105;&#111;&#110;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email</a>,
                     <a href="https://listserv.in2p3.fr/archives/gammapy-coordination-l.html">archives</a>)
                     <br>
                     Use this mailing list to contact the Gammapy coordination committee.

--- a/scripts/link-conversion.js
+++ b/scripts/link-conversion.js
@@ -1,0 +1,20 @@
+'use strict';
+
+document.addEventListener('DOMContentLoaded', function () {
+    const links = document.querySelectorAll('a.link-conversion');
+
+    links.forEach(a => {
+        const rep = a.getAttribute('data-replace');  // e.g. "#", "*", "&"
+        let href = a.getAttribute('href');
+
+        if (rep === '#') href = href.replace('#', '-ld-l@');
+        else if (rep === '*') href = href.replace('*', '-coordination-l@');
+        else if (rep === '&') href = href.replace('&', '-cta-l@');
+
+        // common replacements
+        href = href.replace('/', 'in2p3.fr').replace('email', 'mailto:gammapy');
+
+        a.setAttribute('href', href);
+    });
+});
+

--- a/team.html
+++ b/team.html
@@ -140,7 +140,7 @@
                 <li><strong>Stefan Funk</strong> (Erlangen University, Germany)</li>
             </ul>
             <p>
-                The committee can be contacted by email: <a href="mailto:gammapy-coordination-l@in2p3.fr">gammapy-coordination-l [at] in2p3 [dot] fr</a>.
+                The committee can be contacted by <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#111;&#111;&#114;&#100;&#105;&#110;&#97;&#116;&#105;&#111;&#110;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email </a>
             </p>
 
             <br><br>
@@ -236,7 +236,7 @@
                 <strong>Atreyee Sinha</strong> (TIFR) and <strong>Quentin Remy</strong> (MPIK).
             </p>
             <p>
-                The Lead Developers can be contacted by email: <a href="mailto:gammapy-ld-l@in2p3.fr">gammapy-ld-l [at] in2p3 [dot] fr</a>.
+                The Lead Developers can be contacted by <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#108;&#100;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email</a>.
             </p>
 
             <br><br>

--- a/team.html
+++ b/team.html
@@ -140,7 +140,7 @@
                 <li><strong>Stefan Funk</strong> (Erlangen University, Germany)</li>
             </ul>
             <p>
-                The committee can be contacted by <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#111;&#111;&#114;&#100;&#105;&#110;&#97;&#116;&#105;&#111;&#110;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email </a>
+                The committee can be contacted by <a class="link-conversion" data-replace="*" href="email*/" rel="nofollow noindex">email</a>
             </p>
 
             <br><br>
@@ -236,7 +236,7 @@
                 <strong>Atreyee Sinha</strong> (TIFR) and <strong>Quentin Remy</strong> (MPIK).
             </p>
             <p>
-                The Lead Developers can be contacted by <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#108;&#100;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email</a>.
+                The Lead Developers can be contacted by <a class="link-conversion" data-replace="#" href="email#/" rel="nofollow noindex">email</a>.
             </p>
 
             <br><br>
@@ -373,6 +373,7 @@
     <!-- Footer Section -->
     <div id="footer-placeholder"></div>
     <script src="scripts/load-components.js"></script>
-
+    <script src="scripts/link-conversion.js"></script>   
+    
 </body>
 </html>


### PR DESCRIPTION
Fixes #75
This is to fix the emails, so that bots are less likely to find them. 
This PR utilises the HTML entities option from this webpage:
https://spencermortensen.com/articles/email-obfuscation/#link



```

<!-- gammapy-ld-l@in2p3.fr -->
<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#108;&#100;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email</a>

<!-- gammapy-cta-l@in2p3.fr -->
<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#116;&#97;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">
  gammapy-cta-l@in2p3.fr
</a>

<!-- gammapy-coordination-l@in2p3.fr -->
<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#103;&#97;&#109;&#109;&#97;&#112;&#121;&#45;&#99;&#111;&#111;&#114;&#100;&#105;&#110;&#97;&#116;&#105;&#111;&#110;&#45;&#108;&#64;&#105;&#110;&#50;&#112;&#51;&#46;&#102;&#114;">email </a>

```